### PR TITLE
Improved handling of functions returning an awaitable object

### DIFF
--- a/aioitertools/builtins.py
+++ b/aioitertools/builtins.py
@@ -13,39 +13,21 @@ use with `await`, `async for`, etc.
 
 import asyncio
 import builtins
-import inspect
 from typing import (
     Any,
     AsyncIterable,
     AsyncIterator,
-    Awaitable,
     Callable,
     Iterable,
     List,
     Set,
     Tuple,
-    Union,
     cast,
     overload,
 )
 
+from .helpers import maybe_await
 from .types import AnyIterable, AnyIterator, AnyStop, T, R, T1, T2, T3, T4, T5
-
-
-@overload
-async def maybe_await(object: Awaitable[T]) -> T:
-    pass
-
-
-@overload
-async def maybe_await(object: T) -> T:
-    pass
-
-
-async def maybe_await(object: Union[Awaitable[T], T]) -> T:
-    if inspect.isawaitable(object):
-        return await object  # type: ignore
-    return object  # type: ignore
 
 
 def iter(itr: AnyIterable[T]) -> AsyncIterator[T]:

--- a/aioitertools/helpers.py
+++ b/aioitertools/helpers.py
@@ -1,0 +1,13 @@
+# Copyright 2018 John Reese
+# Licensed under the MIT license
+
+import inspect
+from typing import Awaitable, Union
+
+from .types import T
+
+
+async def maybe_await(object: Union[Awaitable[T], T]) -> T:
+    if inspect.isawaitable(object):
+        return await object  # type: ignore
+    return object  # type: ignore

--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -19,7 +19,7 @@ import itertools
 import operator
 from typing import Any, AsyncIterator, Iterable, List, Optional, Tuple, overload
 
-from .builtins import enumerate, iter, list, next, zip
+from .builtins import enumerate, iter, list, maybe_await, next, zip
 from .types import (
     Accumulator,
     AnyFunction,
@@ -60,14 +60,9 @@ async def accumulate(
         return
 
     yield total
-    if asyncio.iscoroutinefunction(func):
-        async for item in itr:
-            total = await func(total, item)
-            yield total
-    else:
-        async for item in itr:
-            total = func(total, item)
-            yield total
+    async for item in itr:
+        total = await maybe_await(func(total, item))
+        yield total
 
 
 class Chain:
@@ -213,16 +208,10 @@ async def dropwhile(
 
     """
     itr = iter(iterable)
-    if asyncio.iscoroutinefunction(predicate):
-        async for item in itr:
-            if not await predicate(item):
-                yield item
-                break
-    else:
-        async for item in itr:
-            if not predicate(item):
-                yield item
-                break
+    async for item in itr:
+        if not await maybe_await(predicate(item)):
+            yield item
+            break
     async for item in itr:
         yield item
 
@@ -244,14 +233,9 @@ async def filterfalse(
             ...  # 4, 5
 
     """
-    if asyncio.iscoroutinefunction(predicate):
-        async for item in iter(iterable):
-            if not await predicate(item):
-                yield item
-    else:
-        async for item in iter(iterable):
-            if not predicate(item):
-                yield item
+    async for item in iter(iterable):
+        if not await maybe_await(predicate(item)):
+            yield item
 
 
 # pylint: disable=undefined-variable,multiple-statements
@@ -297,27 +281,15 @@ async def groupby(
     item = await next(it)
     grouping = [item]
 
-    if asyncio.iscoroutinefunction(key):
-        j = await key(item)
-        async for item in it:
-            k = await key(item)
-            if k != j:
-                yield j, grouping
-                grouping = [item]
-            else:
-                grouping.append(item)
-            j = k
-
-    else:
-        j = key(item)
-        async for item in it:
-            k = key(item)
-            if k != j:
-                yield j, grouping
-                grouping = [item]
-            else:
-                grouping.append(item)
-            j = k
+    j = await maybe_await(key(item))
+    async for item in it:
+        k = await maybe_await(key(item))
+        if k != j:
+            yield j, grouping
+            grouping = [item]
+        else:
+            grouping.append(item)
+        j = k
 
     yield j, grouping
 
@@ -367,9 +339,9 @@ async def islice(itr: AnyIterable[T], *args: Optional[int]) -> AsyncIterator[T]:
     elif len(args) == 1:
         stop, = args
     elif len(args) == 2:
-        start, stop = args
+        start, stop = args  # type: ignore
     elif len(args) == 3:
-        start, stop, step = args
+        start, stop, step = args  # type: ignore
     assert start >= 0 and (stop is None or stop >= 0) and step >= 0
     step = max(1, step)
 
@@ -460,14 +432,9 @@ async def starmap(
             ...  # 2, 3, 4
 
     """
-    if asyncio.iscoroutinefunction(fn):
-        async for itr in iter(iterable):
-            args = await list(itr)
-            yield await fn(*args)
-    else:
-        async for itr in iter(iterable):
-            args = await list(itr)
-            yield fn(*args)
+    async for itr in iter(iterable):
+        args = await list(itr)
+        yield await maybe_await(fn(*args))
 
 
 async def takewhile(
@@ -487,18 +454,11 @@ async def takewhile(
             ...  # 0, 1, 2, 3
 
     """
-    if asyncio.iscoroutinefunction(predicate):
-        async for item in iter(iterable):
-            if await predicate(item):
-                yield item
-            else:
-                break
-    else:
-        async for item in iter(iterable):
-            if predicate(item):
-                yield item
-            else:
-                break
+    async for item in iter(iterable):
+        if await maybe_await(predicate(item)):
+            yield item
+        else:
+            break
 
 
 def tee(itr: AnyIterable[T], n: int = 2) -> Tuple[AsyncIterator[T], ...]:

--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -19,7 +19,8 @@ import itertools
 import operator
 from typing import Any, AsyncIterator, Iterable, List, Optional, Tuple, overload
 
-from .builtins import enumerate, iter, list, maybe_await, next, zip
+from .builtins import enumerate, iter, list, next, zip
+from .helpers import maybe_await
 from .types import (
     Accumulator,
     AnyFunction,

--- a/aioitertools/tests/__init__.py
+++ b/aioitertools/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from .builtins import BuiltinsTest
 from .itertools import ItertoolsTest
+from .helpers import HelpersTest

--- a/aioitertools/tests/builtins.py
+++ b/aioitertools/tests/builtins.py
@@ -2,10 +2,12 @@
 # Licensed under the MIT license
 
 import asyncio
+import functools
 from typing import AsyncIterator
 from unittest import TestCase
 
 import aioitertools as ait
+from aioitertools.builtins import maybe_await
 from .helpers import async_test
 
 slist = ["A", "B", "C"]
@@ -13,6 +15,37 @@ srange = range(3)
 
 
 class BuiltinsTest(TestCase):
+
+    # aioitertools.maybe_await()
+
+    @async_test
+    async def test_maybe_await(self):
+        self.assertEqual(await maybe_await(42), 42)
+
+    @async_test
+    async def test_maybe_await_async_def(self):
+        async def forty_two():
+            await asyncio.sleep(0.0001)
+            return 42
+
+        self.assertEqual(await maybe_await(forty_two()), 42)
+
+    @async_test
+    async def test_maybe_await_coroutine(self):
+        @asyncio.coroutine
+        def forty_two():
+            yield from asyncio.sleep(0.0001)
+            return 42
+
+        self.assertEqual(await maybe_await(forty_two()), 42)
+
+    @async_test
+    async def test_maybe_await_partial(self):
+        async def multiply(a, b):
+            await asyncio.sleep(0.0001)
+            return a * b
+
+        self.assertEqual(await maybe_await(functools.partial(multiply, 6)(7)), 42)
 
     # aioitertools.iter()
 

--- a/aioitertools/tests/builtins.py
+++ b/aioitertools/tests/builtins.py
@@ -2,12 +2,10 @@
 # Licensed under the MIT license
 
 import asyncio
-import functools
 from typing import AsyncIterator
 from unittest import TestCase
 
 import aioitertools as ait
-from aioitertools.builtins import maybe_await
 from .helpers import async_test
 
 slist = ["A", "B", "C"]
@@ -15,37 +13,6 @@ srange = range(3)
 
 
 class BuiltinsTest(TestCase):
-
-    # aioitertools.maybe_await()
-
-    @async_test
-    async def test_maybe_await(self):
-        self.assertEqual(await maybe_await(42), 42)
-
-    @async_test
-    async def test_maybe_await_async_def(self):
-        async def forty_two():
-            await asyncio.sleep(0.0001)
-            return 42
-
-        self.assertEqual(await maybe_await(forty_two()), 42)
-
-    @async_test
-    async def test_maybe_await_coroutine(self):
-        @asyncio.coroutine
-        def forty_two():
-            yield from asyncio.sleep(0.0001)
-            return 42
-
-        self.assertEqual(await maybe_await(forty_two()), 42)
-
-    @async_test
-    async def test_maybe_await_partial(self):
-        async def multiply(a, b):
-            await asyncio.sleep(0.0001)
-            return a * b
-
-        self.assertEqual(await maybe_await(functools.partial(multiply, 6)(7)), 42)
 
     # aioitertools.iter()
 

--- a/aioitertools/tests/helpers.py
+++ b/aioitertools/tests/helpers.py
@@ -2,6 +2,9 @@
 # Licensed under the MIT license
 
 import asyncio
+import functools
+from unittest import TestCase
+from aioitertools.helpers import maybe_await
 
 
 def async_test(fn):
@@ -10,3 +13,37 @@ def async_test(fn):
         return loop.run_until_complete(fn(*args, **kwargs))
 
     return wrapped
+
+
+class HelpersTest(TestCase):
+
+    # aioitertools.helpers.maybe_await()
+
+    @async_test
+    async def test_maybe_await(self):
+        self.assertEqual(await maybe_await(42), 42)
+
+    @async_test
+    async def test_maybe_await_async_def(self):
+        async def forty_two():
+            await asyncio.sleep(0.0001)
+            return 42
+
+        self.assertEqual(await maybe_await(forty_two()), 42)
+
+    @async_test
+    async def test_maybe_await_coroutine(self):
+        @asyncio.coroutine
+        def forty_two():
+            yield from asyncio.sleep(0.0001)
+            return 42
+
+        self.assertEqual(await maybe_await(forty_two()), 42)
+
+    @async_test
+    async def test_maybe_await_partial(self):
+        async def multiply(a, b):
+            await asyncio.sleep(0.0001)
+            return a * b
+
+        self.assertEqual(await maybe_await(functools.partial(multiply, 6)(7)), 42)


### PR DESCRIPTION
* Add `maybe_await()` to simplify handling possible coroutines
* Switch to using `maybe_await()` on return values rather than `asyncio.iscoroutinefunction()` on functions

Fixes #4



