### PR TITLE
Fix `islice` consuming extra item

### DIFF
--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -337,7 +337,7 @@ async def islice(itr: AnyIterable[T], *args: Optional[int]) -> AsyncIterator[T]:
     step = 1
     if not args:
         raise ValueError("must pass stop index")
-    elif len(args) == 1:
+    if len(args) == 1:
         stop, = args
     elif len(args) == 2:
         start, stop = args  # type: ignore

--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -346,14 +346,15 @@ async def islice(itr: AnyIterable[T], *args: Optional[int]) -> AsyncIterator[T]:
     assert start >= 0 and (stop is None or stop >= 0) and step >= 0
     step = max(1, step)
 
+    if stop == 0:
+        return
+
+    itr = iter(itr)
     async for index, item in enumerate(itr):
-        if index < start:
-            continue
-        if stop is not None and index >= stop:
+        if index >= start and (index - start) % step == 0:
+            yield item
+        if stop is not None and index + 1 >= stop:
             break
-        if (index - start) % step != 0:
-            continue
-        yield item
 
 
 async def permutations(

--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -349,7 +349,6 @@ async def islice(itr: AnyIterable[T], *args: Optional[int]) -> AsyncIterator[T]:
     if stop == 0:
         return
 
-    itr = iter(itr)
     async for index, item in enumerate(itr):
         if index >= start and (index - start) % step == 0:
             yield item

--- a/aioitertools/tests/itertools.py
+++ b/aioitertools/tests/itertools.py
@@ -352,11 +352,13 @@ class ItertoolsTest(TestCase):
             yield 3
             yield 4
 
-        it = ait.islice(gen(), 2)
+        gen_it = gen()
+        it = ait.islice(gen_it, 2)
         for k in [1, 2]:
             self.assertEqual(await ait.next(it), k)
         with self.assertRaises(StopAsyncIteration):
             await ait.next(it)
+        assert await ait.list(gen_it) == [3, 4]
 
     @async_test
     async def test_islice_gen_start_step(self):
@@ -394,11 +396,13 @@ class ItertoolsTest(TestCase):
             yield 3
             yield 4
 
-        it = ait.islice(gen(), 1, 3, 2)
+        gen_it = gen()
+        it = ait.islice(gen_it, 1, 3, 2)
         for k in [2]:
             self.assertEqual(await ait.next(it), k)
         with self.assertRaises(StopAsyncIteration):
             await ait.next(it)
+        assert await ait.list(gen_it) == [4]
 
     @async_test
     async def test_permutations_list(self):


### PR DESCRIPTION
Python's `islice` does not consume it.
```python
>>> from itertools import islice
>>> it = iter((1, 2, 3, 4))
>>> list(islice(it, 1, 3))
[2, 3]
>>> list(it)
[4]
```
But `islice` from version `0.3.0` of `aioitertools` does:
```python
>>> from aioitertools import *
>>> async def main():
...     it = iter((1, 2, 3, 4))
...     print(await list(islice(it, 1, 3)))
...     print(await list(it))
>>> import asyncio
>>> asyncio.run(main())
[2, 3]
[]
```