### PR TITLE
Allow async parameter expansion in chain.from_iterable

### DIFF
--- a/aioitertools/itertools.py
+++ b/aioitertools/itertools.py
@@ -17,7 +17,7 @@ import asyncio
 import builtins
 import itertools
 import operator
-from typing import Any, AsyncIterator, Iterable, List, Optional, Tuple, overload
+from typing import Any, AsyncIterator, List, Optional, Tuple, overload
 
 from .builtins import enumerate, iter, list, next, zip
 from .helpers import maybe_await
@@ -67,7 +67,7 @@ async def accumulate(
 
 
 class Chain:
-    async def __call__(self, *itrs: AnyIterable[T]) -> AsyncIterator[T]:
+    def __call__(self, *itrs: AnyIterable[T]) -> AsyncIterator[T]:
         """
         Yield values from one or more iterables in series.
 
@@ -79,17 +79,17 @@ class Chain:
                 ...  # 1, 2, 3, 7, 8, 9
 
         """
-        async for itr in iter(itrs):
-            async for item in iter(itr):
-                yield item
+        return self.from_iterable(itrs)
 
-    def from_iterable(self, itrs: Iterable[AnyIterable[T]]) -> AsyncIterator[T]:
+    async def from_iterable(self, itrs: AnyIterableIterable[T]) -> AsyncIterator[T]:
         """
         Like chain, but takes an iterable of iterables.
 
         Alias for chain(*itrs)
         """
-        return self(*itrs)
+        async for itr in iter(itrs):
+            async for item in iter(itr):
+                yield item
 
 
 chain = Chain()

--- a/aioitertools/tests/itertools.py
+++ b/aioitertools/tests/itertools.py
@@ -107,6 +107,22 @@ class ItertoolsTest(TestCase):
             await ait.next(it)
 
     @async_test
+    async def test_chain_from_iterable_parameter_expansion_gen(self):
+        async def gen():
+            for k in range(2, 9, 2):
+                yield k
+
+        async def parameters_gen():
+            yield slist
+            yield gen()
+
+        it = ait.chain.from_iterable(parameters_gen())
+        for k in ["A", "B", "C", 2, 4, 6, 8]:
+            self.assertEqual(await ait.next(it), k)
+        with self.assertRaises(StopAsyncIteration):
+            await ait.next(it)
+
+    @async_test
     async def test_combinations(self):
         it = ait.combinations(range(4), 3)
         for k in [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)]:


### PR DESCRIPTION
Fix:
```
Traceback (most recent call last)
<ipython-input-9-4b8ec88c205a> in async-def-wrapper()
      1 it = aioitertools.zip_longest(aiter1(), aiter2(), fillvalue=None)
----> 2 async for item in aioitertools.chain.from_iterable(it):
      3     if not item:
      4         continue
      5     print(item)

/usr/local/lib/python3.7/dist-packages/aioitertools/itertools.py in from_iterable(self, itrs)
     90         Alias for chain(*itrs)
     91         """
---> 92         return self(*itrs)
     93 
     94 

TypeError: Chain object argument after * must be an iterable, not async_generator
```