### PR TITLE
Concurrency-limited version of gather

### DIFF
--- a/aioitertools/asyncio.py
+++ b/aioitertools/asyncio.py
@@ -9,7 +9,7 @@ Provisional library.  Must be imported as `aioitertools.asyncio`.
 
 import asyncio
 import time
-from typing import Awaitable, Iterable, Optional, Set, Tuple, cast
+from typing import Any, Awaitable, Dict, Iterable, List, Optional, Set, Tuple, cast
 
 from .types import AsyncIterator, T
 
@@ -66,3 +66,66 @@ async def as_completed(
 
         for item in done:
             yield await item
+
+
+async def gather(
+    *args: Awaitable[T],
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    return_exceptions: bool = False,
+    limit: int = -1
+) -> List[Any]:
+    """Like asyncio.gather but with a limit on concurrency.
+
+    Much of the complexity of gather comes with it support for cancel, which we
+    omit here.  Note that all results are buffered.
+    """
+
+    # For detecting input duplicates and reconciling them at the end
+    input_map: Dict[Awaitable[T], List[int]] = {}
+    # This is keyed on what we'll get back from asyncio.wait
+    pos: Dict[asyncio.Future[T], int] = {}
+    ret: List[Any] = [None] * len(args)
+
+    pending: Set[asyncio.Future[T]] = set()
+    done: Set[asyncio.Future[T]] = set()
+
+    next_arg = 0
+
+    while True:
+        while next_arg < len(args) and (limit == -1 or len(pending) < limit):
+            # We have to defer the creation of the Task as long as possible
+            # because once we do, it starts executing, regardless of what we
+            # have in the pending set.
+            if args[next_arg] in input_map:
+                input_map[args[next_arg]].append(next_arg)
+            else:
+                # We call ensure_future directly to ensure that we have a Task
+                # because the return value of asyncio.wait will be an implicit
+                # task otherwise, and we won't be able to know which input it
+                # corresponds to.
+                task: asyncio.Future[T] = asyncio.ensure_future(args[next_arg])
+                pending.add(task)
+                pos[task] = next_arg
+                input_map[args[next_arg]] = [next_arg]
+            next_arg += 1
+
+        # pending might be empty if the last items of args were dupes;
+        # asyncio.wait([]) will raise an exception.
+        if pending:
+            done, pending = await asyncio.wait(
+                pending, loop=loop, return_when=asyncio.FIRST_COMPLETED
+            )
+            for x in done:
+                if return_exceptions and x.exception():
+                    ret[pos[x]] = x.exception()
+                else:
+                    ret[pos[x]] = x.result()
+
+        if not pending and next_arg == len(args):
+            break
+
+    for lst in input_map.values():
+        for i in range(1, len(lst)):
+            ret[lst[i]] = ret[lst[0]]
+
+    return ret

--- a/aioitertools/tests/asyncio.py
+++ b/aioitertools/tests/asyncio.py
@@ -50,3 +50,81 @@ class AsyncioTest(TestCase):
             async for _ in aio.as_completed(futures, timeout=0.5):
                 results += 1
         self.assertEqual(results, 1)
+
+    @async_test
+    async def test_gather_input_types(self):
+        async def fn(arg):
+            await asyncio.sleep(0.001)
+            return arg
+
+        fns = [fn(1), asyncio.ensure_future(fn(2))]
+        if hasattr(asyncio, "create_task"):
+            # 3.7 only
+            fns.append(asyncio.create_task(fn(3)))  # pylint: disable=no-member
+        else:
+            fns.append(fn(3))
+
+        result = await aio.gather(*fns)
+        self.assertEqual([1, 2, 3], result)
+
+    @async_test
+    async def test_gather_limited(self):
+        max_counter = 0
+        counter = 0
+
+        async def fn(arg):
+            nonlocal counter, max_counter
+            counter += 1
+            if max_counter < counter:
+                max_counter = counter
+            await asyncio.sleep(0.001)
+            counter -= 1
+            return arg
+
+        # Limit of 2
+        result = await aio.gather(*[fn(i) for i in range(10)], limit=2)
+        self.assertEqual(2, max_counter)
+        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], result)
+
+        # No limit
+        result = await aio.gather(*[fn(i) for i in range(10)])
+        self.assertEqual(
+            10, max_counter
+        )  # TODO: on a loaded machine this might be less?
+        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], result)
+
+    @async_test
+    async def test_gather_limited_dupes(self):
+        async def fn(arg):
+            await asyncio.sleep(0.001)
+            return arg
+
+        f = fn(1)
+        g = fn(2)
+        result = await aio.gather(f, f, f, g, f, g, limit=2)
+        self.assertEqual([1, 1, 1, 2, 1, 2], result)
+
+        f = fn(1)
+        g = fn(2)
+        result = await aio.gather(f, f, f, g, f, g)
+        self.assertEqual([1, 1, 1, 2, 1, 2], result)
+
+    @async_test
+    async def test_gather_with_exceptions(self):
+        class MyException(Exception):
+            pass
+
+        async def fn(arg, fail=False):
+            await asyncio.sleep(arg)
+            if fail:
+                raise MyException(arg)
+            return arg
+
+        with self.assertRaises(MyException):
+            await aio.gather(fn(0.002, fail=True), fn(0.001))
+
+        result = await aio.gather(
+            fn(0.002, fail=True), fn(0.001), return_exceptions=True
+        )
+        self.assertEqual(result[1], 0.001)
+        self.assertIsInstance(result[0], MyException)


### PR DESCRIPTION
This is the simplest possible version that can work, and isn't yet done.

Still needs:
- to handle duplicated inputs
- removal of prints
- exception handling
- what to do about cancel?

Any suggestions at this point?