### PR TITLE
Platform independent encoding on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
-with open("README.md") as f:
+with open("README.md", encoding="utf8") as f:
     readme = f.read()
 
-with open("aioitertools/__init__.py") as f:
+with open("aioitertools/__init__.py", encoding="utf8") as f:
     for line in f:
         if line.startswith("__version__"):
             version = line.split('"')[1]


### PR DESCRIPTION
### Description
Specify encoding on open files in setup to prevent errors like this
```
File "/tmp/pip-build-bs2nhzzy/aioitertools/setup.py", line 4, in <module>
         readme = f.read()
File "/opt/python3.6/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 897: ordinal not in range(128)
```

Fixes: #15
